### PR TITLE
fix delegate status label in dark mode

### DIFF
--- a/src/pages/DelegateMonitor.vue
+++ b/src/pages/DelegateMonitor.vue
@@ -196,7 +196,7 @@ export default class DelegateMonitor extends Vue {
   flex: 1;
   flex-direction: column;
   align-items: center;
-  background-color: #f3f3f399;
+  background-color: #f2f2f224;
   border: 1px solid var(--theme-border);
   border-bottom: none;
 }


### PR DESCRIPTION
Delegate type status label is not visible in dark mode.

Before:
![image](https://user-images.githubusercontent.com/26366184/82417890-85d25e00-9a7c-11ea-84e8-eee75265d3c1.png)
![image](https://user-images.githubusercontent.com/26366184/82417751-4b68c100-9a7c-11ea-9b78-31a5ea73995c.png)

After:
![image](https://user-images.githubusercontent.com/26366184/82417935-9a165b00-9a7c-11ea-8fdc-06bc6b8eaa01.png)
![image](https://user-images.githubusercontent.com/26366184/82417715-3b50e180-9a7c-11ea-9d41-47be8684318a.png)

Removing the `background-color` property entirely works as well.