### PR TITLE
Fixed UnikType icon display issue in Safari 14.0.1

### DIFF
--- a/src/components/unik/UnikTypeBadge.vue
+++ b/src/components/unik/UnikTypeBadge.vue
@@ -28,6 +28,7 @@ export default class UnikTypeBadge extends Vue {
 .unik-badge img {
   margin-right: 0.5em;
   width: 1.2em;
+  height: 1.2em;
 }
 
 .unik-badge.unik-badge-individual {

--- a/src/components/unik/UnikTypeLogo.vue
+++ b/src/components/unik/UnikTypeLogo.vue
@@ -20,6 +20,7 @@ export default class UnikTypeLogo extends Vue {
   margin-right: 0.2em;
   border-radius: 2px;
   width: 1em;
+  height: 1em;
 }
 
 .unik.unik-individual {


### PR DESCRIPTION
This PR fixes an issue with the height of "Unik type" icons in the latest version of Safari (v14.0.1 - macOS Big Sur).

Before:
![Screenshot 2020-11-18 at 23 40 12](https://user-images.githubusercontent.com/38882571/99597042-a9f50480-29f7-11eb-9a14-f6ce2e91498c.png)
After:
![Screenshot 2020-11-18 at 23 40 18](https://user-images.githubusercontent.com/38882571/99597049-ae212200-29f7-11eb-9c78-2a5d1ccd1bcc.png)

